### PR TITLE
[SquashFS] Add builder method to specify custom modification time

### DIFF
--- a/src/NyaFs/Filesystem/SquashFs/SquashFsBuilder.cs
+++ b/src/NyaFs/Filesystem/SquashFs/SquashFsBuilder.cs
@@ -528,6 +528,12 @@ namespace NyaFs.Filesystem.SquashFs
             }
         }
 
+        public SquashFsBuilder WithModificationDateTime(DateTime ModificationDateTime)
+        {
+            Superblock.ModificationTime = Universal.Helper.FsHelper.ConvertToUnixTimestamp(ModificationDateTime);
+            return this;
+        }
+
         /// <summary>
         /// Get builded filesystem image
         /// </summary>

--- a/src/NyaFs/Filesystem/SquashFs/SquashFsBuilder.cs
+++ b/src/NyaFs/Filesystem/SquashFs/SquashFsBuilder.cs
@@ -528,9 +528,9 @@ namespace NyaFs.Filesystem.SquashFs
             }
         }
 
-        public SquashFsBuilder WithModificationDateTime(DateTime ModificationDateTime)
+        public SquashFsBuilder SetModificationTimestamp(DateTime ModificationTimestamp)
         {
-            Superblock.ModificationTime = Universal.Helper.FsHelper.ConvertToUnixTimestamp(ModificationDateTime);
+            Superblock.ModificationTime = Universal.Helper.FsHelper.ConvertToUnixTimestamp(ModificationTimestamp);
             return this;
         }
 


### PR DESCRIPTION
This makes it possible to generate 2 identical SquashFS images, because it no longer depends on ModificationDate.

Useful for testing!
